### PR TITLE
Fix slow movement on certain camera angles

### DIFF
--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -96,7 +96,9 @@ func handle_controls(delta):
 	input.x = Input.get_axis("move_left", "move_right")
 	input.z = Input.get_axis("move_forward", "move_back")
 	
-	movement_velocity = view.basis * input * movement_speed * delta
+	input  = input.rotated(Vector3.UP, view.rotation.y).normalized()
+	
+	movement_velocity = input * movement_speed * delta
 	
 	# Jumping
 	


### PR DESCRIPTION
Rotating the cameras to certain angles like a pure top down angle will cause the player to slow down when moving in some directions, this makes movement speed consistent on all camera angles Input is also normalized just in case