### PR TITLE
Fix a bug where the player rotate to an angle of 0.0 when jumping twice

### DIFF
--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -48,7 +48,7 @@ func _physics_process(delta):
 	
 	# Rotation
 	
-	if velocity.length() > 0:
+	if Vector2(velocity.z, velocity.x).length() > 0:
 		rotation_direction = Vector2(velocity.z, velocity.x).angle()
 		
 	rotation.y = lerp_angle(rotation.y, rotation_direction, delta * 10)


### PR DESCRIPTION
### Step to reproduce
Rotate the player to an angle different from 0.0 (initial angle) and jump twice (simple or double jump) the player will rotate back to an angle of 0.0.