### PR TITLE
Fix HUD label did not update after coins collected

### DIFF
--- a/scenes/main.tscn
+++ b/scenes/main.tscn
@@ -161,3 +161,5 @@ offset_right = 368.0
 offset_bottom = 123.0
 text = "0"
 label_settings = SubResource("LabelSettings_38ys3")
+
+[connection signal="coin_collected" from="Player" to="HUD" method="_on_coin_collected"]


### PR DESCRIPTION
The signal was not connected so the coin count is always 0.