### PR TITLE
Make falling platform frame rate independent

### DIFF
--- a/objects/platform_falling.gd
+++ b/objects/platform_falling.gd
@@ -1,19 +1,19 @@
 extends Node3D
 
 var falling := false
-var gravity := 0.0
+var fall_velocity := 0.0
 
 func _process(delta):
 	scale = scale.lerp(Vector3(1, 1, 1), delta * 10) # Animate scale
 	
-	position.y -= gravity * delta
+	if falling:
+		fall_velocity += 15.0 * delta
+		position.y -= fall_velocity * delta
+	else:
+		fall_velocity = 0.0
 	
 	if position.y < -10:
 		queue_free() # Remove platform if below threshold
-	
-	if falling:
-		gravity += 15.0 * delta
-
 
 func _on_body_entered(_body):
 	if !falling:

--- a/objects/platform_falling.gd
+++ b/objects/platform_falling.gd
@@ -3,7 +3,7 @@ extends Node3D
 var falling := false
 var fall_velocity := 0.0
 
-func _process(delta):
+func _physics_process(delta):
 	scale = scale.lerp(Vector3(1, 1, 1), delta * 10) # Animate scale
 	
 	if falling:

--- a/objects/platform_falling.gd
+++ b/objects/platform_falling.gd
@@ -12,7 +12,7 @@ func _process(delta):
 		queue_free() # Remove platform if below threshold
 	
 	if falling:
-		gravity += 0.25
+		gravity += 15.0 * delta
 
 
 func _on_body_entered(_body):


### PR DESCRIPTION
A simple fix, but an undoubtedly important one. New value of 15 assumed a target of 60fps. (0.25 * 60)

Platform logic should also be in physics_process since the player is physics based.