### PR TITLE
Fix walking animation speed with analog movement

### DIFF
--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -93,6 +93,12 @@ func handle_effects(delta):
 
 		elif animation.current_animation != "idle":
 			animation.play("idle", 0.1)
+			
+		if animation.current_animation == "walk":
+			animation.speed_scale = speed_factor
+		else:
+			animation.speed_scale = 1.0
+			
 	elif animation.current_animation != "jump":
 		animation.play("jump", 0.1)
 


### PR DESCRIPTION
Re-implements analog walking animation speed for analog movement which was unintentionally removed by 78aafa45f30ef051fae3eac23aaea1e9fe6c478c